### PR TITLE
ci: stop letting Codecov upload gate merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
       - name: Tree-shaking size guard
         run: pnpm size-check
 
+      # Coverage is observability, not correctness: a Codecov outage or a missing
+      # CODECOV_TOKEN must never fail `test`, which branch protection gates merges on.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## Problem

`main` has been red since 2026-07-08 and PR #43 shows `test=FAILURE` — but the test suite is green (419/419 locally, 31 files). The only failing step is the coverage upload:

```
error -- Upload queued for processing failed: {"message":"Token required - not valid tokenless upload"}
==> Failed to run upload-coverage
##[error]Process completed with exit code 1.
```

The repo has no `CODECOV_TOKEN` secret, and Codecov no longer accepts the tokenless upload (most likely since the `big-decimal` → `decimal128` rename, which breaks its by-name project match).

Because `fail_ci_if_error: true`, that rejection fails the whole `test` job — and `test` is what branch protection gates on. Consequence: PR #43 cannot merge, and the dependabot auto-merge queue is stuck behind the same gate.

## Fix

Set `fail_ci_if_error: false`. Coverage reporting is observability, not correctness; a third-party service's availability should not have the power to block a merge into `main`.

## Follow-up (needs repo admin)

Adding a `CODECOV_TOKEN` secret restores actual coverage reporting. That is the complete fix; this PR only removes its power to gate merges.

https://claude.ai/code/session_01Un4CzKKxdCHVL4s7wXZgrC