### PR TITLE
fix(dectest): only treat `--` outside quotes as a comment

### DIFF
--- a/tests/dectest/parse.test.ts
+++ b/tests/dectest/parse.test.ts
@@ -48,6 +48,11 @@ describe("parseDecTest", () => {
     expect(cases[0]).toMatchObject({ expected: "2", conditions: [] });
   });
 
+  it("treats a double dash inside a quoted operand as data, not a comment", () => {
+    const cases = parseDecTest(`dqcom001 compare '--' "a--b" -> -1  -- quoted dashes\n`);
+    expect(cases[0]).toMatchObject({ operands: ["--", "a--b"], expected: "-1", conditions: [] });
+  });
+
   it("records the source line for failure messages", () => {
     expect(parseDecTest(SAMPLE)[0].line).toBe(11);
   });

--- a/tests/dectest/parse.ts
+++ b/tests/dectest/parse.ts
@@ -23,9 +23,20 @@ export interface DecTestCase {
 const TOKEN_RE = /'[^']*'|"[^"]*"|\S+/g;
 const DIRECTIVE_RE = /^(\w+):\s*(.*)$/;
 
+/** A `--` only opens a comment outside quotes: `compare '--' "a--b"` carries two literal operands. */
 function stripComment(line: string): string {
-  const at = line.indexOf("--");
-  return (at >= 0 ? line.slice(0, at) : line).trim();
+  let quote = "";
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === quote) quote = "";
+    } else if (ch === "'" || ch === '"') {
+      quote = ch;
+    } else if (ch === "-" && line[i + 1] === "-") {
+      return line.slice(0, i).trim();
+    }
+  }
+  return line.trim();
 }
 
 function unquote(token: string): string {


### PR DESCRIPTION
Prerequisite for decTest Phase 2 (`compare` / `round` / `format` / predicates).

## Problem

The decTest grammar opens a comment at `--` **unless it sits inside a quoted string**. `stripComment` used a bare `indexOf("--")`:

```ts
const at = line.indexOf("--");
```

So a line like

```
dqcom001 compare '--' "a--b" -> -1
```

is truncated to `dqcom001 compare `, fails the `arrow < 2` guard, and is **silently dropped**. No error, no failing test — the vector simply disappears from the suite.

None of the five vendored arithmetic fixtures quote a `--`, so nothing regressed today. `dqCompare` and friends do, which is why this lands before Phase 2 rather than after.

## Fix

Scan the line character by character, tracking which quote character (`'` or `"`) opened the current string, and cut only at a `--` found outside one. Doubled-quote escapes (`'it''s'`) fall out correctly: the toggles balance and the scan ends outside quotes.

## Verification

- New regression test covers both quote styles in one line.
- Parsed case count over the vendored fixtures is **unchanged: 3192 before, 3192 after** — the fix opens up quoted dashes without shifting any existing cut point.
- Full suite green: 420 tests (419 + the new one), `tsc --noEmit` clean.

https://claude.ai/code/session_01Un4CzKKxdCHVL4s7wXZgrC